### PR TITLE
feat: release checklist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 > A GitHub App built with [Probot](https://github.com/probot/probot) that A Probot app
 
+## Overview
+
+This bot helps to have better project management in our Swarm/Bee related repositories. Its current capabilities are:
+
+ - add labels to new issues and PRs to distinguish them in Zenhub
+ - support commands `label` and `unlabel` to add/remove labels
+ - add release checklist to release PRs 
+
 ## Setup
 
 ```sh
@@ -22,6 +30,17 @@ Possible configuration:
 labels:
   issue: <<some other name for issue label>>
   pull-request: <<some other name for pull-request label>>
+release:
+  # Trigger conditions are joined with AND, hence if you specify both title and labels both has to be present!
+  trigger:
+    title: <<regex that validates the name of the PR>>
+    labels: 
+      - <<label(s) that has to be present on PR>>
+  checklist: |
+    # Release checklist
+    This content is placed into comment into the PR.
+    
+     - [ ] Do something before you release!
 ```
 
 ## Contributing

--- a/release-checklist.js
+++ b/release-checklist.js
@@ -1,0 +1,62 @@
+/**
+ * This function checks if for given PR the bot should create the comment with checklist.
+ * This handle is expected to be triggered with `pull_request.opened` event, so it should be guranteed
+ * that for lifespan of a PR this will be triggered only once and hence we should not worry about
+ * duplication of checklist comments.
+ * @param context
+ * @param config
+ * @returns {Promise<boolean>}
+ */
+async function isReleasePr (context, config) {
+  if (!config || !config.release || !config.release.checklist || !config.release.trigger) {
+    console.log('Release Checklist is not configured')
+
+    return false
+  }
+
+  const prInfo = (await context.octokit.pulls.get(context.pullRequest())).data
+  const titleRegex = config.release.trigger.title
+  const labels = typeof config.release.trigger.labels === 'string' ? [config.release.trigger.labels] : config.release.trigger.labels
+
+  if (!titleRegex && !labels) {
+    console.log('No triggers provided')
+    return false
+  }
+
+  if (titleRegex) {
+    if(!new RegExp(titleRegex).test(prInfo.title)){
+      console.log(`Title '${prInfo.title}' does NOT match regex: ${titleRegex}`)
+
+      return false
+    }
+
+    console.log('Title regex does match.')
+  }
+
+  if (labels) {
+    for (const label of labels) {
+      if (!prInfo.labels.find(l => l.name === label)) {
+        console.log(`Expected label '${label}' not found!`)
+
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+async function handleReleaseChecklist (context) {
+  const config = await context.config('config.yaml')
+
+  if (!await isReleasePr(context, config)) {
+    return
+  }
+
+  const checklist = config.release.checklist
+  return context.octokit.issues.createComment(context.issue({
+    body: checklist
+  }));
+}
+
+module.exports = handleReleaseChecklist


### PR DESCRIPTION
Us (BeeGees) team has defined release process with a predefined step (checklist) to do while releasing a new version. I was looking into way how to help this process by providing checklist directly into our automatically created release PR by [release-please](https://github.com/googleapis/release-please).

This PR introduces support for Release checklist to bee-worker. It works in a way that if the repo has configured checklist in `.github/config.yaml` than it will pass it into a PR that meets "trigger" conditions. Currently supported triggers are:
 - PR title regex
 - required label(s)
 